### PR TITLE
Set the Content-Type header to application/x-www-form-urlencoded

### DIFF
--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -61,6 +61,8 @@ func TestLoginScreen(t *testing.T) {
 		} else {
 			// create a request with body to post
 			req, _ := http.NewRequest("POST", "/", strings.NewReader(e.postedData.Encode()))
+			// set the Content-Type header
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 			// get our context with the session
 			ctx := getCtx(req)


### PR DESCRIPTION
I found that by not setting the Content-Type header then the parameters will not be correctly passed to the handler. So in the case of this file the email and password will never make it through to the test Authenticate function in test-repo.go.